### PR TITLE
Feature/optimize parallel routes schema

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,10 +2,12 @@
   "editor.formatOnSave": true,
   "editor.tabSize": 2,
   "editor.insertSpaces": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.tslint": true
+  },
+  "editor.codeActionsOnSaveTimeout": 10000,
   "files.eol": "\n",
   "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "tslint.autoFixOnSave": true,
-  "tslint.configFile": "node_modules/@magicspace/configs/tslint-vscode.js"
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/core/src/library/index.ts
+++ b/core/src/library/index.ts
@@ -2,3 +2,4 @@ export * from './route-match';
 export * from './router';
 export * from './schema';
 export * from './history';
+export * from './route-group';

--- a/core/src/library/route-group.ts
+++ b/core/src/library/route-group.ts
@@ -1,3 +1,3 @@
 export class RouteGroup {
-  constructor(public $group: string) {}
+  constructor(readonly $group: string) {}
 }

--- a/core/src/library/route-group.ts
+++ b/core/src/library/route-group.ts
@@ -1,0 +1,3 @@
+export class RouteGroup {
+  constructor(public $group: string) {}
+}

--- a/core/src/library/schema.ts
+++ b/core/src/library/schema.ts
@@ -12,13 +12,8 @@ export interface RouteSchema {
   $extension?: object;
 }
 
-export interface RouteRootSchema extends RouteSchema {
-  $group?: string;
-}
-
 export type RouteSchemaDict = Dict<RouteSchema | boolean>;
-
-export type RouteRootSchemaDict = Dict<RouteRootSchema | boolean>;
+export type RouteGroupSchemaDict = Dict<RouteSchemaDict>;
 
 export function schema<T extends RouteSchemaDict>(schema: T): T {
   return schema;

--- a/core/src/library/schema.ts
+++ b/core/src/library/schema.ts
@@ -13,7 +13,7 @@ export interface RouteSchema {
 }
 
 export type RouteSchemaDict = Dict<RouteSchema | boolean>;
-export type GroupNameToRouteSchemaDictDict = Dict<RouteSchemaDict>;
+export type GroupToRouteSchemaDictDict = Dict<RouteSchemaDict>;
 
 export function schema<T extends RouteSchemaDict>(schema: T): T {
   return schema;

--- a/core/test/match.test.ts
+++ b/core/test/match.test.ts
@@ -250,6 +250,13 @@ test('should match `multiple.mixed`', async () => {
   expect(router.multiple.number.$matched).toBe(false);
 });
 
+test('should match `$group`', async () => {
+  expect(router.default.$group).toBe(undefined);
+  expect(router.account.id.$group).toBe(undefined);
+  expect(router.$.popup.$group).toBe('popup');
+  expect(router.$.popup.invite.$group).toBe('popup');
+});
+
 test('should match parallel `account`, `friends` and `invite`', async () => {
   history.push('/account');
 

--- a/react/examples/parallel-routes/main.tsx
+++ b/react/examples/parallel-routes/main.tsx
@@ -13,20 +13,6 @@ const router = Router.create(
     default: {
       $match: '',
     },
-    account: {
-      $exact: true,
-      $group: 'popup',
-      $children: {
-        login: true,
-        register: true,
-      },
-    },
-    profile: {
-      $group: 'popup',
-    },
-    cart: {
-      $group: 'sidebar',
-    },
     news: true,
     about: {
       $exact: true,
@@ -39,10 +25,25 @@ const router = Router.create(
       $match: RouteMatch.rest,
     },
   },
+  {
+    popup: {
+      account: {
+        $exact: true,
+        $children: {
+          login: true,
+          register: true,
+        },
+      },
+      profile: true,
+    },
+    sidebar: {
+      cart: true,
+    },
+  },
   history,
 );
 
-router.about.$parallel({matches: [router.cart]});
+router.about.$parallel({matches: [router.$.sidebar.cart]});
 router.contact.$parallel({groups: ['popup']});
 
 router.about.$beforeEnter(match => {
@@ -60,16 +61,16 @@ export class App extends Component {
         <Route match={router.default}>
           <p>Home page</p>
           <div>
-            <Link to={router.account} toggle>
+            <Link to={router.$.popup.account} toggle>
               Account
             </Link>
             {' | '}
-            <Link to={router.profile} toggle>
+            <Link to={router.$.popup.profile} toggle>
               Profile
             </Link>
           </div>
           <div>
-            <Link to={router.cart}>Cart</Link>
+            <Link to={router.$.sidebar.cart}>Cart</Link>
           </div>
           <div>
             <Link to={router.news}>News</Link>
@@ -86,7 +87,7 @@ export class App extends Component {
             </Link>
           </div>
         </Route>
-        <Route match={router.account}>
+        <Route match={router.$.popup.account}>
           <div
             style={{
               position: 'fixed',
@@ -107,27 +108,27 @@ export class App extends Component {
                 x
               </a>
             </p>
-            <Route match={router.account} exact={true}>
+            <Route match={router.$.popup.account} exact={true}>
               <p>
-                <Link to={router.account.login}>Login</Link>
+                <Link to={router.$.popup.account.login}>Login</Link>
                 <br />
-                <Link to={router.account.register}>Register</Link>
+                <Link to={router.$.popup.account.register}>Register</Link>
               </p>
               <p>
-                <Link to={router.profile}>Profile</Link>
+                <Link to={router.$.popup.profile}>Profile</Link>
               </p>
             </Route>
-            <Route match={router.account.login}>
+            <Route match={router.$.popup.account.login}>
               <p>- Login</p>
-              <Link to={router.account}>Back</Link>
+              <Link to={router.$.popup.account}>Back</Link>
             </Route>
-            <Route match={router.account.register}>
+            <Route match={router.$.popup.account.register}>
               <p>- Register</p>
-              <Link to={router.account}>Back</Link>
+              <Link to={router.$.popup.account}>Back</Link>
             </Route>
           </div>
         </Route>
-        <Route match={router.profile}>
+        <Route match={router.$.popup.profile}>
           <div
             style={{
               position: 'fixed',
@@ -149,11 +150,11 @@ export class App extends Component {
               </a>
             </p>
             <p>
-              <Link to={router.account}>Account</Link>
+              <Link to={router.$.popup.account}>Account</Link>
             </p>
           </div>
         </Route>
-        <Route match={router.cart}>
+        <Route match={router.$.sidebar.cart}>
           <div
             style={{
               position: 'fixed',

--- a/react/package.json
+++ b/react/package.json
@@ -13,7 +13,7 @@
     "build:library": "rimraf bld/library && tsc -p src/library",
     "typecheck:examples": "./scripts/typecheck-examples.sh",
     "lint:library": "tslint -p src/library",
-    "lint:examples": "./scripts/typecheck-examples.sh",
+    "lint:examples": "./scripts/lint-examples.sh",
     "test:library": "yarn build:library && yarn lint:library",
     "test:examples": "yarn typecheck:examples && yarn lint:examples",
     "test": "yarn test:library && yarn test:examples"


### PR DESCRIPTION
```
let router = Router.create(
  /* primary schema */
  {
    /* /app/foo */
    foo: {},
    /* /app/bar */
    bar: true
  },
  /* group schema */
  { 
    /* /app?_groupA=/foo */
    groupA: {
      foo: true
    },
    /* /app?_groupB=/foo */
    groupB: {
      foo: {}
    }
  },
  history,
  options
);

router.foo
router.$.groupA
```